### PR TITLE
Update chat.prompty

### DIFF
--- a/src/api/contoso_chat/chat.prompty
+++ b/src/api/contoso_chat/chat.prompty
@@ -8,9 +8,9 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    azure_deployment: gpt-35-turbo
+    azure_deployment: gpt-4o-mini
     azure_endpoint: ${ENV:AZURE_OPENAI_ENDPOINT}
-    api_version: 2023-07-01-preview
+    api_version: 2024-07-18
   parameters:
     max_tokens: 128
     temperature: 0.2


### PR DESCRIPTION
Change azure_demelopment model to GPT-4o-mini. The reasons for doing this are - 

- OpenAI recently announced GPT-3.5-turbo as a "Legacy Model," so they are not providing any more support.
- GPT-4o-mini is a more efficient and cost-efficient model than GPT-3.5-Turbo.